### PR TITLE
feat: integrate supabase auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,6 @@
     <p class="register-link">Don't have an account? <a href="register.html">Register</a></p>
   </div>
 
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -21,6 +21,6 @@
     <p id="registerMessage" aria-live="polite"></p>
     <p class="login-link">Already have an account? <a href="index.html">Log In</a></p>
   </div>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/reset.html
+++ b/reset.html
@@ -16,6 +16,6 @@
     </form>
     <p id="resetMessage" aria-live="polite"></p>
   </div>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,24 +1,36 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
+
+const supabaseUrl = 'https://your-project-url.supabase.co';
+const supabaseAnonKey = 'your-anon-key';
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
 const loginForm = document.getElementById('loginForm');
 const changeEmailContainer = document.querySelector('.change-email');
 const changeEmailLink = document.getElementById('changeEmail');
 
 if (loginForm) {
-  loginForm.addEventListener('submit', function (e) {
+  loginForm.addEventListener('submit', async function (e) {
     e.preventDefault();
     const email = document.getElementById('email').value;
     const password = document.getElementById('password').value;
     const messageEl = document.getElementById('message');
-
-    // Simple demo credentials. Replace with real authentication.
-    if (email === 'test@example.com' && password === 'password123') {
-      messageEl.textContent = 'Login successful! 🎉';
-      messageEl.style.color = '#00ff99';
-      changeEmailContainer?.classList.add('hidden');
-      setTimeout(() => {
-        window.location.href = 'profile.html';
-      }, 500);
-    } else {
-      messageEl.textContent = 'Invalid email or password';
+    messageEl.textContent = '';
+    try {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) {
+        messageEl.textContent = error.message;
+        messageEl.style.color = '#ff3344';
+        changeEmailContainer?.classList.remove('hidden');
+      } else {
+        messageEl.textContent = 'Login successful! 🎉';
+        messageEl.style.color = '#00ff99';
+        changeEmailContainer?.classList.add('hidden');
+        setTimeout(() => {
+          window.location.href = 'profile.html';
+        }, 500);
+      }
+    } catch (err) {
+      messageEl.textContent = 'Network error. Please try again.';
       messageEl.style.color = '#ff3344';
       changeEmailContainer?.classList.remove('hidden');
     }
@@ -39,25 +51,50 @@ if (changeEmailLink) {
 
 const resetForm = document.getElementById('resetForm');
 if (resetForm) {
-  resetForm.addEventListener('submit', function (e) {
+  resetForm.addEventListener('submit', async function (e) {
     e.preventDefault();
     const email = document.getElementById('resetEmail').value;
     const messageEl = document.getElementById('resetMessage');
-    messageEl.textContent = 'If an account with that email exists, a reset link has been sent.';
-    messageEl.style.color = '#00ff99';
+    messageEl.textContent = '';
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email);
+      if (error) {
+        messageEl.textContent = error.message;
+        messageEl.style.color = '#ff3344';
+      } else {
+        messageEl.textContent = 'If an account with that email exists, a reset link has been sent.';
+        messageEl.style.color = '#00ff99';
+      }
+    } catch (err) {
+      messageEl.textContent = 'Network error. Please try again.';
+      messageEl.style.color = '#ff3344';
+    }
   });
 }
 
 const registerForm = document.getElementById('registerForm');
 if (registerForm) {
-  registerForm.addEventListener('submit', function (e) {
+  registerForm.addEventListener('submit', async function (e) {
     e.preventDefault();
     const email = document.getElementById('registerEmail').value;
+    const password = document.getElementById('registerPassword').value;
     const messageEl = document.getElementById('registerMessage');
-    messageEl.textContent = 'Registration successful! You can now log in.';
-    messageEl.style.color = '#00ff99';
-    setTimeout(() => {
-      window.location.href = 'index.html';
-    }, 1000);
+    messageEl.textContent = '';
+    try {
+      const { error } = await supabase.auth.signUp({ email, password });
+      if (error) {
+        messageEl.textContent = error.message;
+        messageEl.style.color = '#ff3344';
+      } else {
+        messageEl.textContent = 'Registration successful! Check your email to confirm.';
+        messageEl.style.color = '#00ff99';
+        setTimeout(() => {
+          window.location.href = 'index.html';
+        }, 1000);
+      }
+    } catch (err) {
+      messageEl.textContent = 'Network error. Please try again.';
+      messageEl.style.color = '#ff3344';
+    }
   });
 }


### PR DESCRIPTION
## Summary
- load Supabase JS client and initialize with project URL and anon key
- replace hard-coded auth with Supabase sign-in, sign-up, and reset flows
- add user-facing error handling for failed requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68905a25eb548329af7f326c79dda28d