### PR TITLE
feat: add dedicated login page

### DIFF
--- a/login.html
+++ b/login.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skill Swap Login</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="login-container">
+    <h1>Log In</h1>
+    <form id="loginForm">
+      <label for="email">Email</label>
+      <input type="email" id="email" placeholder="email@example.com" required>
+
+      <label for="password">Password</label>
+      <input type="password" id="password" placeholder="Password" required>
+
+      <button type="submit" class="fun-button">Log In</button>
+    </form>
+    <p id="message" aria-live="polite"></p>
+    <p class="change-email hidden"><a href="#" id="changeEmail">Use a different email</a></p>
+    <p class="reset-link"><a href="reset.html">Forgot your password?</a></p>
+    <p class="register-link">Don't have an account? <a href="register.html">Register</a></p>
+  </div>
+
+  <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -19,7 +19,7 @@
       <button type="submit" class="fun-button">Register</button>
     </form>
     <p id="registerMessage" aria-live="polite"></p>
-    <p class="login-link">Already have an account? <a href="index.html">Log In</a></p>
+    <p class="login-link">Already have an account? <a href="login.html">Log In</a></p>
   </div>
   <script type="module" src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -89,7 +89,7 @@ if (registerForm) {
         messageEl.textContent = 'Registration successful! Check your email to confirm.';
         messageEl.style.color = '#00ff99';
         setTimeout(() => {
-          window.location.href = 'index.html';
+          window.location.href = 'login.html';
         }, 1000);
       }
     } catch (err) {

--- a/server.js
+++ b/server.js
@@ -11,7 +11,14 @@ const mimeTypes = {
 };
 
 const server = http.createServer((req, res) => {
-  let filePath = req.url === '/' ? '/index.html' : req.url;
+  let filePath;
+  if (req.url === '/') {
+    filePath = '/index.html';
+  } else if (req.url === '/login') {
+    filePath = '/login.html';
+  } else {
+    filePath = req.url;
+  }
   const ext = path.extname(filePath);
   const contentType = mimeTypes[ext] || 'text/plain';
   fs.readFile(path.join(__dirname, filePath), (err, content) => {


### PR DESCRIPTION
## Summary
- copy current login markup to new `login.html`
- update navigation and scripts to use `login.html`
- serve `login.html` on `/login` requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890b6c8304c8329a65f6faaafdc7728