### PR TITLE
Use environment variables for Supabase configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+SUPABASE_URL=your-project-url
+SUPABASE_ANON_KEY=your-anon-key

--- a/config.js
+++ b/config.js
@@ -1,0 +1,2 @@
+export const supabaseUrl = process.env.SUPABASE_URL;
+export const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;

--- a/script.js
+++ b/script.js
@@ -1,7 +1,6 @@
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
+import { supabaseUrl, supabaseAnonKey } from './config.js';
 
-const supabaseUrl = 'https://your-project-url.supabase.co';
-const supabaseAnonKey = 'your-anon-key';
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 const loginForm = document.getElementById('loginForm');


### PR DESCRIPTION
## Summary
- load Supabase URL and anon key from environment variables instead of hard-coding
- introduce config module to expose environment variables

## Testing
- `npm test`
- `curl -s -o - -w "\nHTTP_CODE:%{http_code}\n" -X POST "https://$SUPABASE_URL.supabase.co/auth/v1/token?grant_type=password" -H "apikey: $SUPABASE_ANON_KEY" -H "Content-Type: application/json" -d '{"email":"example@example.com","password":"example"}'` *(fails: HTTP_CODE 000)*


------
https://chatgpt.com/codex/tasks/task_e_6890b6d62ef883298f4efe1b527d3807